### PR TITLE
Changed string 'false' to false

### DIFF
--- a/Setup/InstallSchema.php
+++ b/Setup/InstallSchema.php
@@ -22,7 +22,7 @@ class InstallSchema implements \Magento\Framework\Setup\InstallSchemaInterface
                     'id',
                     \Magento\Framework\DB\Ddl\Table::TYPE_INTEGER,
                     null,
-                    [ 'identity' => true, 'unsigned' => true, 'nullable' => 'false',
+                    [ 'identity' => true, 'unsigned' => true, 'nullable' => false,
                                     'primary' => true, 'comment' => 'the rule id']
                 )->addColumn(
                     'dest_country_id',


### PR DESCRIPTION
'false' is a string, so true. This was causing an breaking error when you run bin/magento setup:upgrade.

So my conclusion here is; this release was not tested on an empty m2 installation. Is this someting you can do before releasing? To keep the quality level high! :)